### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.30
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/code-statistics.yml
+++ b/.github/workflows/code-statistics.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.1
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[anthropics/claude-code-action](https://github.com/anthropics/claude-code-action)** published a new release **[v1.0.30](https://github.com/anthropics/claude-code-action/releases/tag/v1.0.30)** on 2026-01-16T22:16:48Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v6.0.1](https://github.com/actions/checkout/releases/tag/v6.0.1)** on 2025-12-02T16:38:59Z
