### PR TITLE
feat: add org-wide FUNDING.yml for GitHub sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: xemantic


### PR DESCRIPTION
Adds FUNDING.yml to enable GitHub sponsors across all Xemantic repositories.

Closes #19

Generated with [Claude Code](https://claude.ai/code)