### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1.0.108
+        uses: anthropics/claude-code-action@v1.0.110
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1.0.108
+        uses: anthropics/claude-code-action@v1.0.110
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[anthropics/claude-code-action](https://github.com/anthropics/claude-code-action)** published a new release **[v1.0.110](https://github.com/anthropics/claude-code-action/releases/tag/v1.0.110)** on 2026-04-29T03:30:34Z
