### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -78,7 +78,7 @@ jobs:
           java-version: ${{ inputs.java_version || vars.DEFAULT_JAVA_VERSION }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6.1.0
+        uses: gradle/actions/setup-gradle@v6.2.0
 
       - name: Set environment variables
         if: inputs.env != ''

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1.0.140
+        uses: anthropics/claude-code-action@v1.0.147
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1.0.140
+        uses: anthropics/claude-code-action@v1.0.147
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[anthropics/claude-code-action](https://github.com/anthropics/claude-code-action)** published a new release **[v1.0.147](https://github.com/anthropics/claude-code-action/releases/tag/v1.0.147)** on 2026-06-12T21:55:51Z
* **[gradle/actions](https://github.com/gradle/actions)** published a new release **[v6.2.0](https://github.com/gradle/actions/releases/tag/v6.2.0)** on 2026-06-12T15:53:34Z
