### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Setup Java
-        uses: actions/setup-java@v5.3.0
+        uses: actions/setup-java@v5.4.0
         with:
           distribution: ${{ inputs.java_distribution || vars.DEFAULT_JAVA_DISTRIBUTION }}
           java-version: ${{ inputs.java_version || vars.DEFAULT_JAVA_VERSION }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1.0.157
+        uses: anthropics/claude-code-action@v1.0.162
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1.0.157
+        uses: anthropics/claude-code-action@v1.0.162
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[anthropics/claude-code-action](https://github.com/anthropics/claude-code-action)** published a new release **[v1.0.162](https://github.com/anthropics/claude-code-action/releases/tag/v1.0.162)** on 2026-07-01T20:47:33Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v5.4.0](https://github.com/actions/setup-java/releases/tag/v5.4.0)** on 2026-06-25T15:38:03Z
